### PR TITLE
sequencer additions/fixes

### DIFF
--- a/qdev_wrappers/customised_instruments/AWGinterface.py
+++ b/qdev_wrappers/customised_instruments/AWGinterface.py
@@ -1,0 +1,119 @@
+from broadbean.types import ForgedSequenceType
+from broadbean.plotting import plotter
+
+
+class AWGInterface:
+
+    def upload(self, forged_sequence: ForgedSequenceType):
+        raise NotImplementedError()
+
+    def set_infinit_loop(self, element_index: int,
+                         true_on_false_off: bool):
+        raise NotImplementedError()
+
+    def set_repeated_element(self, index):
+        raise NotImplementedError()
+
+    def set_repeated_element_series(self, start_index, stop_index):
+        raise NotImplementedError()
+
+    def repeat_full_sequence(self):
+        raise NotImplementedError()
+
+    def get_SR(self):
+        raise NotImplementedError()
+
+
+class SimulatedAWGInterface(AWGInterface):
+    def __init__(self):
+        self.forged_sequence = None
+
+    def upload(self, forged_sequence: ForgedSequenceType):
+        print(f'uploading')
+        SR = self.get_SR()
+        self.forged_sequence = forged_sequence
+        plotter(forged_sequence, SR=SR)
+
+    def set_repeated_element(self, index):
+        print(f'setting repeated element to {index}')
+        # AWG is not zero indexed but one, convert to zero index
+        index -= 1
+        if self.forged_sequence is None:
+            print(f'but there was not sequence uploaded')
+            return
+        plotter(self.forged_sequence[index], SR=self.get_SR())
+
+    def set_repeated_element_series(self, start_index, stop_index):
+        print(f'setting repeated element series from {start_index} to '
+              f'{stop_index}')
+        # AWG is not zero indexed but one, convert to zero index
+        start_index -= start_index
+        stop_index -= stop_index
+        if self.forged_sequence is None:
+            print(f'but there was not sequence uploaded')
+            return
+        plotter(self.forged_sequence[start_index:stop_index], SR=self.get_SR())
+
+    def repeat_full_sequence(self):
+        print(f'repeating full series')
+        plotter(self.forged_sequence, SR=self.get_SR())
+
+    def get_SR(self):
+        # fake this for now
+        return 1e9
+
+
+class AWG5014Interface(AWGInterface):
+    def __init__(self, awg):
+        self.awg = awg
+        self.last_repeated_element = None
+        self.forged_sequence = None
+        self.last_repeated_element_series = (None, None)
+
+    def upload(self, forged_sequence: ForgedSequenceType):
+        self.awg.make_send_and_load_awg_file_from_forged_sequence(
+            forged_sequence)
+        self.forged_sequence = forged_sequence
+        # uploading a sequence results in reverting the information on the
+        # elements
+        self.last_repeated_element = None
+        self.last_repeated_element_series = (None, None)
+        self.awg.all_channels_on()
+        self.awg.run()
+
+    def set_repeated_element(self, index):
+        print(f'stop repeating {self.last_repeated_element} start {index}')
+        self.awg.set_sqel_loopcnt_to_inf(index, state=1)
+        self.awg.sequence_pos(index)
+        if (self.last_repeated_element is not None and
+                self.last_repeated_element != index):
+            self.awg.set_sqel_loopcnt_to_inf(self.last_repeated_element,
+                                             state=0)
+        self.last_repeated_element = index
+
+    def set_repeated_element_series(self, start_index, stop_index):
+        self._restore_sequence_state()
+        self.awg.set_sqel_goto_target_index(stop_index, start_index)
+        self.awg.sequence_pos(start_index)
+
+    def repeat_full_sequence(self):
+        self._restore_sequence_state()
+        self.awg.sequence_pos(1)
+
+    def get_SR(self):
+        return self.awg.clock_freq()
+
+    def _restore_sequence_state(self):
+        if self.last_repeated_element is not None:
+            self.awg.set_sqel_loopcnt_to_inf(self.last_repeated_element,
+                                             state=0)
+        lres = self.last_repeated_element_series
+        if lres[0] is not None or lres[1] is not None:
+            assert (lres[0] is not None and
+                    lres[1] is not None and
+                    self.forged_sequence is not None)
+            if lres[0] == len(self.forged_sequence):
+                goto_element = 1
+            else:
+                goto_element = 0
+            self.awg.set_sqel_goto_target_index(lres[0], goto_element)

--- a/qdev_wrappers/customised_instruments/parametric_sequencer.py
+++ b/qdev_wrappers/customised_instruments/parametric_sequencer.py
@@ -126,8 +126,8 @@ class ParametricSequencer(Instrument):
         # add it before the upload so that if there is a crash, the
         # state that is causing the crash is captured in the metadata
         # TODO: add serialization of the elements
-        self.metadata['template_element'] = template_element
-        self.metadata['initial_element'] = initial_element
+        # self.metadata['template_element'] = template_element
+        # self.metadata['initial_element'] = initial_element
 
         # add sequence symbols as qcodes parameters
         self.sequence.parameters = {}

--- a/qdev_wrappers/customised_instruments/parametric_sequencer.py
+++ b/qdev_wrappers/customised_instruments/parametric_sequencer.py
@@ -19,6 +19,7 @@ from broadbean.element import Element
 from broadbean.segment import in_context
 from broadbean.plotting import plotter
 
+from qdev_wrappers.customised_instruments.AWGinterface import AWGInterface
 
 log = logging.getLogger(__name__)
 
@@ -32,122 +33,6 @@ def make_setpoints_tuple(tuple) -> Union[None, Setpoints]:
     if tuple is None:
         return None
     return Setpoints(*tuple)
-
-
-class AWGInterface:
-
-    def upload(self, forged_sequence: ForgedSequenceType):
-        raise NotImplementedError()
-
-    def set_infinit_loop(self, element_index: int,
-                         true_on_false_off: bool):
-        raise NotImplementedError()
-
-    def set_repeated_element(self, index):
-        raise NotImplementedError()
-
-    def set_repeated_element_series(self, start_index, stop_index):
-        raise NotImplementedError()
-
-    def repeat_full_sequence(self):
-        raise NotImplementedError()
-
-    def get_SR(self):
-        raise NotImplementedError()
-
-
-class SimulatedAWGInterface(AWGInterface):
-    def __init__(self):
-        self.forged_sequence = None
-
-    def upload(self, forged_sequence: ForgedSequenceType):
-        print(f'uploading')
-        SR = self.get_SR()
-        self.forged_sequence = forged_sequence
-        plotter(forged_sequence, SR=SR)
-
-    def set_repeated_element(self, index):
-        print(f'setting repeated element to {index}')
-        # AWG is not zero indexed but one, convert to zero index
-        index -= 1
-        if self.forged_sequence is None:
-            print(f'but there was not sequence uploaded')
-            return
-        plotter(self.forged_sequence[index], SR=self.get_SR())
-
-    def set_repeated_element_series(self, start_index, stop_index):
-        print(f'setting repeated element series from {start_index} to '
-              f'{stop_index}')
-        # AWG is not zero indexed but one, convert to zero index
-        start_index -= start_index
-        stop_index -= stop_index
-        if self.forged_sequence is None:
-            print(f'but there was not sequence uploaded')
-            return
-        plotter(self.forged_sequence[start_index:stop_index], SR=self.get_SR())
-
-    def repeat_full_sequence(self):
-        print(f'repeating full series')
-        plotter(self.forged_sequence, SR=self.get_SR())
-
-    def get_SR(self):
-        # fake this for now
-        return 1e6
-
-
-class AWG5014Interface(AWGInterface):
-    def __init__(self, awg):
-        self.awg = awg
-        self.last_repeated_element = None
-        self.forged_sequence = None
-        self.last_repeated_element_series = (None, None)
-
-    def upload(self, forged_sequence: ForgedSequenceType):
-        self.awg.make_send_and_load_awg_file_from_forged_sequence(forged_sequence)
-        self.forged_sequence = forged_sequence
-        # uploading a sequence results in reverting the information on the
-        # elements
-        self.last_repeated_element = None
-        self.last_repeated_element_series = (None, None)
-        self.awg.all_channels_on()
-        self.awg.run()
-
-    def set_repeated_element(self, index):
-        print(f'stop repeating {self.last_repeated_element} start {index}')
-        self.awg.set_sqel_loopcnt_to_inf(index, state=1)
-        self.awg.sequence_pos(index)
-        if (self.last_repeated_element is not None and
-            self.last_repeated_element != index):
-            self.awg.set_sqel_loopcnt_to_inf(self.last_repeated_element,
-                                             state=0)
-        self.last_repeated_element = index
-
-    def set_repeated_element_series(self, start_index, stop_index):
-        self._restore_sequence_state()
-        self.awg.set_sqel_goto_target_index(stop_index, start_index)
-        self.awg.sequence_pos(start_index)
-
-    def repeat_full_sequence(self):
-        self._restore_sequence_state()
-        self.awg.sequence_pos(1)
-
-    def get_SR(self):
-        return self.awg.clock_freq()
-
-    def _restore_sequence_state(self):
-        if self.last_repeated_element is not None:
-            self.awg.set_sqel_loopcnt_to_inf(self.last_repeated_element,
-                                             state=0)
-        lres = self.last_repeated_element_series
-        if lres[0] is not None or lres[1] is not None:
-            assert (lres[0] is not None and
-                    lres[1] is not None and
-                    self.forged_sequence is not None)
-            if lres[0] == len(self.forged_sequence):
-                goto_element = 1
-            else:
-                goto_element = 0
-            self.awg.set_sqel_goto_target_index(lres[0], goto_element)
 
 
 class SequenceChannel(InstrumentChannel):
@@ -256,8 +141,6 @@ class ParametricSequencer(Instrument):
                                                 self._set_context_parameter,
                                                 name),
                                             initial_value=value)
-
-
             if inner_setpoints is not None or outer_setpoints is not None:
                 self.set_setpoints(inner=inner_setpoints,
                                    outer=outer_setpoints)
@@ -295,6 +178,8 @@ class ParametricSequencer(Instrument):
                                       set_cmd=partial(
                                           self._set_repeated_element,
                                           set_inner=setpoints == inner),
+                                      unit=self._units.get(symbol, ''),
+                                      label=self._labels.get(symbol, ''),
                                       initial_value=setpoints.values[0])
         self._do_sync_repetion_state = True
         # define shortcuts (with long names, I know)
@@ -369,12 +254,12 @@ class ParametricSequencer(Instrument):
             if self._outer_setpoints is None:
                 index = self._inner_index
             else:
-                index = (self._outer_index*len(self._outer_setpoints.values) +
-                    self._inner_index)
+                index = (self._outer_index * len(self._outer_setpoints.values) +
+                         self._inner_index)
             index += 1
             if self.initial_element is not None:
                 index += 1
-            self.awg.set_repeated_element(index)
+            self.awg.set_repeated_element(int(index))
             # # assert correct mode
             # if self._outer_setpoints:
             #     index = (outer_index*len(self._outer_setpoints.values) +
@@ -393,12 +278,13 @@ class ParametricSequencer(Instrument):
                 raise RuntimeWarning('Cannot set repeated outer setpoint '
                                      'when repeat mode is "inner"')
 
-
     @staticmethod
     def _value_to_index(value, setpoints):
-        values = np.asarray(setpoints.values)
-        index = (np.abs(values - value)).argmin()
-        return index
+        if type(value) is str:
+            return setpoints.values.index(value)
+        else:
+            values = np.asarray(setpoints.values)
+            return (np.abs(values - value)).argmin()
 
     # Private methods
     def _upload_sequence(self):

--- a/qdev_wrappers/pulse_building/atoms_ext.py
+++ b/qdev_wrappers/pulse_building/atoms_ext.py
@@ -1,0 +1,34 @@
+import numpy as np
+from broadbean.atoms import atom
+
+
+@atom
+def sine_multi(time, frequencies=None, amplitudes=1, phases=0):
+    if time.size == 1:
+        return 0
+    if frequencies is None:
+        frequencies = [0]
+    if type(amplitudes) in [int, float]:
+        amplitudes = np.ones(len(frequencies)) * amplitudes
+    if type(phases) in [int, float]:
+        phases = np.ones(len(frequencies)) * phases
+    if not (len(frequencies) == len(amplitudes) and
+            len(frequencies) == len(phases)):
+        raise Exception(
+            '{} frequencies, {} amplitudes and {} phases provided'.format(
+                len(frequencies), len(amplitudes), len(phases)))
+    output = np.zeros(time.shape)
+    for i, frequency in enumerate(frequencies):
+        output += amplitudes[i] * \
+            np.sin(frequency * 2 * np.pi * time + phases[i])
+    return output / len(frequencies)
+
+
+@atom
+def gaussianDRAG(time, sigma_cutoff=4, amplitude=1, DRAG=False):
+    sigma = time[-1] / (2 * sigma_cutoff)
+    t = time - time[-1] / 2
+    if DRAG:
+        return amplitude * t / sigma * np.exp(-(t / (2. * sigma))**2)
+    else:
+        return amplitude * np.exp(-(t / (2. * sigma))**2)


### PR DESCRIPTION
- allows setpoints to be strings
- gets set_repeated_element to work (previously failed as parameter wasn't allowed to be a numpy int64)
- adds labels and units to repeated_elements
- comment out element in metadata so that the branch can be used while the element is not serialisable